### PR TITLE
limit preconnect sockets to only active sockets

### DIFF
--- a/lib/agent-pool.js
+++ b/lib/agent-pool.js
@@ -57,59 +57,54 @@ module.exports = class AgentPool {
        *
        * If not, we create agent without preconnected sockets
        */
-      const socketMetas = [
-        ...getSocketMetaInfo(this.activeAgent.sockets),
-        ...getSocketMetaInfo(this.activeAgent.freeSockets)
-      ];
-      if (socketMetas.length > 0) {
-        this.logger.info(
-          `Creating Preconnect agent with socket pool of ${socketMetas.length}`
-        );
-        this.isBusy = true;
-        const newAgent = this.createAgent();
-        for (const meta of socketMetas) {
-          /**
-           * Create a pool of sockets in the new agent and establish the connection to the
-           * backend host with the meta information
-           * https://github.com/node-modules/agentkeepalive/blob/82ff0e85bfbc282c4bad1ccfabf46d4a82943f6d/lib/_http_agent.js#L251
-           *
-           * This method takes care of DNS + TCP + SSL + (Reuses existing TLS session for new sockets belonging to same hosts)
-           */
-          newAgent.createSocket(
-            meta.request,
-            meta.options,
-            (err, createdSocket) => {
-              if (err) {
-                this.logger.error(
-                  { err },
-                  "Failed to create preconnect socket for",
-                  meta.options.host
-                );
-                return;
-              }
-              createdSocket._httpMessage = {
-                shouldKeepAlive: true
-              };
-              /**
-               * Assign it to the freeSockets pool once we have created a socket
-               * https://github.com/node-modules/agentkeepalive/blob/master/lib/_http_agent.js#L75
-               *
-               * Agent takes care of adding the socket to the proper backend host
-               */
-              createdSocket.emit("free");
-            }
-          );
-        }
+      const socketMetas = getSocketMetaInfo(this.activeAgent.sockets);
+      this.logger.info(
+        `Creating Preconnect agent with socket pool of ${socketMetas.length}`
+      );
+      this.isBusy = true;
+      const newAgent = this.createAgent();
+      for (const meta of socketMetas) {
         /**
-         * Instead of relying on newly created sockets ready/connect events and
-         * checking if it hits maxFreeSockets limit(300), we activate the new agent
-         * after quarter of destroy time(20 seconds) has elapsed, since its a safe bet
+         * Create a pool of sockets in the new agent and establish the connection to the
+         * backend host with the meta information
+         * https://github.com/node-modules/agentkeepalive/blob/82ff0e85bfbc282c4bad1ccfabf46d4a82943f6d/lib/_http_agent.js#L251
+         *
+         * This method takes care of DNS + TCP + SSL + (Reuses existing TLS session for new sockets belonging to same hosts)
          */
-        setTimeout(
-          () => this.setActiveAgent(newAgent),
-          Number(this.destroyTime / 3)
+        newAgent.createSocket(
+          meta.request,
+          meta.options,
+          (err, createdSocket) => {
+            if (err) {
+              this.logger.error(
+                { err },
+                "Failed to create preconnect socket for",
+                meta.options.host
+              );
+              return;
+            }
+            createdSocket._httpMessage = {
+              shouldKeepAlive: true
+            };
+            /**
+             * Assign it to the freeSockets pool once we have created a socket
+             * https://github.com/node-modules/agentkeepalive/blob/master/lib/_http_agent.js#L75
+             *
+             * Agent takes care of adding the socket to the proper backend host
+             */
+            createdSocket.emit("free");
+          }
         );
       }
+      /**
+       * Instead of relying on newly created sockets ready/connect events and
+       * checking if it hits maxFreeSockets limit(300), we activate the new agent
+       * after quarter of destroy time(20 seconds) has elapsed, since its a safe bet
+       */
+      setTimeout(
+        () => this.setActiveAgent(newAgent),
+        Number(this.destroyTime / 3)
+      );
     } else {
       this.logger.debug("Creating agent without preconnected sockets");
       const newAgent = this.createAgent();


### PR DESCRIPTION
+ do not include sockets from freeSocket pool when creating pre-connect sockets. Results in lots of unused sockets. 